### PR TITLE
Transform 위젯을 사용해 아이콘을 넘치게 만듦

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:toonflix/widgets/button.dart';
 
 void main() {
-  runApp(App());
+  runApp(const App());
 }
 
 class App extends StatelessWidget {
+  const App({super.key});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -110,12 +112,15 @@ class App extends StatelessWidget {
                 height: 20,
               ),
               Container(
+                //overflow 되면 어떤 동작 할건지 정해 줌.
+                clipBehavior: Clip.hardEdge,
                 decoration: BoxDecoration(
                     color: const Color(0xff1F2123),
                     borderRadius: BorderRadius.circular(25)),
                 child: Padding(
                   padding: const EdgeInsets.all(30),
                   child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -153,6 +158,17 @@ class App extends StatelessWidget {
                           )
                         ],
                       ),
+                      Transform.scale(
+                        scale: 2.2,
+                        child: Transform.translate(
+                          offset: const Offset(-5, 12),
+                          child: const Icon(
+                            Icons.euro_rounded,
+                            color: Colors.white,
+                            size: 88,
+                          ),
+                        ),
+                      )
                     ],
                   ),
                 ),


### PR DESCRIPTION
- Transform.scale 을 사용해 아이콘의 크기를 커지게 만듦
- Transform.translate를 통해 아이콘을 Container 밖으로 이동시킴
- 카드의 최상단인 Container의 clipBehavior 파라미터를 통해 넘친 부분을 잘름